### PR TITLE
Enhance defcustom definitions

### DIFF
--- a/show-notes/Emacs-Lisp-04.org
+++ b/show-notes/Emacs-Lisp-04.org
@@ -448,13 +448,13 @@ We're going convert a couple of the variables from last time into customizable v
 
   (defcustom dotfiles-folder "~/.dotfiles"
     "The folder where dotfiles and org-mode configuration files are stored."
-    :type 'string
+    :type 'directory
     :group 'dotfiles)
 
   (defcustom dotfiles-org-files '()
     "The list of org-mode files under the `dotfiles-folder' which
   contain configuration files that should be tangled"
-    :type '(list string)
+    :type '(repeat string)
     :group 'dotfiles)
 
   (defun dotfiles-tangle-org-file (&optional org-file)


### PR DESCRIPTION
While there is a `list'` type in `defcustom`, it is meant for a very specific list. `'(list string)` means that you want a list with exactly one string. `'(list string function)` means that the customizable variable should take two elements: a string and a function.

However, we want arbitrary many strings, that's what `repeat` is for, e.g. 

```lisp
(defcustom my-favourite-numbers '()
  "A collection of my favourite numbers"
  :type '(repeat integer))
```

Note that we could probably use `file` instead of `string` in `dotfiles-org-files`, but I don't know how to make customize's auto-completion recognize the `dotfiles-folder` as search-folder. To enable auto-completion on the latter, we can use the `:type` `'directory`.