### PR TITLE
feat: Add ability to automatically org-babel based on file category

### DIFF
--- a/Emacs.org
+++ b/Emacs.org
@@ -565,16 +565,36 @@ You can add more =src= block templates below by copying one of the lines and cha
 This snippet adds a hook to =org-mode= buffers so that =efs/org-babel-tangle-config= gets executed each time such a buffer gets saved.  This function checks to see if the file being saved is the Emacs.org file you're looking at right now, and if so, automatically exports the configuration here to the associated output files.
 
 #+begin_src emacs-lisp
+;; This allows you to tell org-babel to tangle you org files after
+;; save by placing:
+;; #+CATEGORY: Configuration
+;; in the head of the org file.
+;; Change this search key/term to what best suits the individual
+(setq efs/tangle-search-key "CATEGORY")
+(setq efs/tangle-search-term "Configuration")
 
-  ;; Automatically tangle our Emacs.org config file when we save it
-  (defun efs/org-babel-tangle-config ()
-    (when (string-equal (file-name-directory (buffer-file-name))
-                        (expand-file-name user-emacs-directory))
-      ;; Dynamic scoping to the rescue
-      (let ((org-confirm-babel-evaluate nil))
-        (org-babel-tangle))))
+(defun efs/org-global-props (&optional efs/property)
+  "Get the plists of global org properties of current buffer."
+  (interactive)
+  (unless efs/property (setq efs/property "PROPERTY"))
+  (org-element-map (org-element-parse-buffer)
+      'keyword (lambda (el) (when (string-match efs/property (org-element-property :key el)) el))))
 
-  (add-hook 'org-mode-hook (lambda () (add-hook 'after-save-hook #'efs/org-babel-tangle-config)))
+(defun efs/org-global-prop-value (key)
+  "Get global org property KEY of current buffer."
+  (org-element-property :value (car (efs/org-global-props key))))
+
+;; Automatically tangle our Emacs.org config file when we save it
+(defun efs/org-babel-tangle-config ()
+  "Used to tangle org file when it change."
+  (when (or (string-equal (file-name-directory (buffer-file-name))
+                          (expand-file-name user-emacs-directory))
+            (string-equal (efs/org-global-prop-value efs/tangle-search-key) efs/tangle-search-term))
+    ;; Dynamic scoping to the rescue
+    (let ((org-confirm-babel-evaluate nil))
+      (org-babel-tangle))))
+
+(add-hook 'org-mode-hook (lambda () (add-hook 'after-save-hook #'efs/org-babel-tangle-config)))
 
 #+end_src
 
@@ -995,7 +1015,7 @@ Dired is a built-in file manager for Emacs that does some pretty amazing things!
 - =*= - Lots of other auto-marking functions
 - =k= / =K= - "Kill" marked items (refresh buffer with =g= / =g r= to get them back)
 - Many operations can be done on a single file if there are no active marks!
- 
+
 **** Copying and Renaming files
 
 - =C= - Copy marked files (or if no files are marked, the current file)

--- a/init.el
+++ b/init.el
@@ -373,10 +373,35 @@
 (add-to-list 'org-structure-template-alist '("el" . "src emacs-lisp"))
 (add-to-list 'org-structure-template-alist '("py" . "src python"))
 
+;; This allows you to tell org-babel to tangle you org files after
+;; save by placing:
+;; #+CATEGORY: Configuration
+;; in the head of the org file.
+;; Change this search key/term to what best suits the individual
+(setq efs/tangle-search-key "CATEGORY")
+(setq efs/tangle-search-term "Configuration")
+
+(defun efs/org-global-props (&optional efs/property)
+  "Get the plists of global org properties of current buffer.
+Takes as argument EFS/PROPERTY"
+  (interactive)
+  (unless efs/property (setq efs/property "PROPERTY"))
+  (org-element-map (org-element-parse-buffer)
+      'keyword (lambda (el)
+                 (when (string-match efs/property (org-element-property :key el))
+                   el))))
+
+(defun efs/org-global-prop-value (key)
+  "Get global org property KEY of current buffer."
+  (org-element-property :value (car (efs/org-global-props key))))
+
 ;; Automatically tangle our Emacs.org config file when we save it
 (defun efs/org-babel-tangle-config ()
-  (when (string-equal (file-name-directory (buffer-file-name))
-                      (expand-file-name user-emacs-directory))
+  "Used to tangle org file when it change."
+  (when (or (string-equal (file-name-directory (buffer-file-name))
+                          (expand-file-name user-emacs-directory))
+            (string-equal (efs/org-global-prop-value efs/tangle-search-key)
+                          efs/tangle-search-term))
     ;; Dynamic scoping to the rescue
     (let ((org-confirm-babel-evaluate nil))
       (org-babel-tangle))))


### PR DESCRIPTION
Using Emacs is a tool for productivity that performs functions with minimal
effort. Therefore, I have added functionality that makes org-babel run in
`org-mode` based on the file level property which the user chooses. This will
help to give a productivity boost to the user.

If applied, this commit will:
  - Run `orb-babel` automatically when the file level `CATEGORY` property is present
    and have a value of `Configuration`
  - Fixes #38 