### PR TITLE
Update Hydra Comment in Emacs.org

### DIFF
--- a/Emacs.org
+++ b/Emacs.org
@@ -346,7 +346,7 @@ This Prescient configuration is optimized for use in System Crafters videos and 
 
 ** Text Scaling
 
-This is an example of using [[https://github.com/abo-abo/hydra][Hydra]] to design a transient key binding for quickly adjusting the scale of the text on screen.  We define a hydra that is bound to =C-s t s= and, once activated, =j= and =k= increase and decrease the text scale.  You can press any other key (or =f= specifically) to exit the transient key map.
+This is an example of using [[https://github.com/abo-abo/hydra][Hydra]] to design a transient key binding for quickly adjusting the scale of the text on screen.  We define a hydra that is bound to =C-SPC t s= and, once activated, =j= and =k= increase and decrease the text scale.  You can press any other key (or =f= specifically) to exit the transient key map.
 
 #+begin_src emacs-lisp
 


### PR DESCRIPTION
Hey, just noticed that the Keybinding in UI Configuration::Text scaling is described as =C-s t s= But I believe it is =C-SPC t s=
I don't know though...Is it worth a PR...? ;)