### PR TITLE
Use nerd-icons for doom-modeline

### DIFF
--- a/Emacs.org
+++ b/Emacs.org
@@ -237,11 +237,13 @@ This configuration uses [[https://evil.readthedocs.io/en/latest/index.html][evil
 
 [[https://github.com/seagle0128/doom-modeline][doom-modeline]] is a very attractive and rich (yet still minimal) mode line configuration for Emacs.  The default configuration is quite good but you can check out the [[https://github.com/seagle0128/doom-modeline#customize][configuration options]] for more things you can enable or disable.
 
-*NOTE:* The first time you load your configuration on a new machine, you'll need to run `M-x all-the-icons-install-fonts` so that mode line icons display correctly.
+*NOTE:* The first time you load your configuration on a new machine, you'll need to run `M-x nerd-icons-install-fonts` so that mode line icons display correctly, also run `M-x all-the-icons-install-fonts`.
 
 #+begin_src emacs-lisp
 
 (use-package all-the-icons)
+
+(use-package nerd-icons)
 
 (use-package doom-modeline
   :init (doom-modeline-mode 1)

--- a/init.el
+++ b/init.el
@@ -142,6 +142,8 @@
 
 (use-package all-the-icons)
 
+(use-package nerd-icons)
+
 (use-package doom-modeline
   :init (doom-modeline-mode 1)
   :custom ((doom-modeline-height 15)))


### PR DESCRIPTION
Per doom-modeline [FAQ](https://github.com/seagle0128/doom-modeline#faq) they switched from [all-the-icons](https://github.com/domtronn/all-the-icons.el) to [nerd-icons](https://github.com/rainstormstudio/nerd-icons.el) and all-the-icons support stopped since `4.0.0`. There are also nerd-icons for dired and treemacs if needed.