### PR TITLE
Improved automatic tangling logic in Emacs.org

### DIFF
--- a/Emacs.org
+++ b/Emacs.org
@@ -612,15 +612,11 @@ This snippet adds a hook to =org-mode= buffers so that =efs/org-babel-tangle-con
 
 #+begin_src emacs-lisp
 
-  ;; Automatically tangle our Emacs.org config file when we save it
-  (defun efs/org-babel-tangle-config ()
-    (when (string-equal (file-name-directory (buffer-file-name))
-                        (expand-file-name user-emacs-directory))
-      ;; Dynamic scoping to the rescue
-      (let ((org-confirm-babel-evaluate nil))
-        (org-babel-tangle))))
-
-  (add-hook 'org-mode-hook (lambda () (add-hook 'after-save-hook #'efs/org-babel-tangle-config)))
+  ;; Automatically tangle any org file in our emacs directory when we save it.
+  (add-hook 'org-mode-hook (lambda ()
+    (when (string-equal (file-name-directory (buffer-file-name)) (expand-file-name user-emacs-directory))
+      (add-hook 'after-save-hook (lambda ()
+        (let ((org-confirm-babel-evaluate nil)) (org-babel-tangle)))))))
 
 #+end_src
 

--- a/Emacs.org
+++ b/Emacs.org
@@ -613,10 +613,11 @@ This snippet adds a hook to =org-mode= buffers so that =efs/org-babel-tangle-con
 #+begin_src emacs-lisp
 
   ;; Automatically tangle any org file in our emacs directory when we save it.
+  (defun my/org-babel-tangle-no-confirm ()
+    (let ((org-confirm-babel-evaluate nil)) (org-babel-tangle)))
   (add-hook 'org-mode-hook (lambda ()
     (when (string-equal (file-name-directory (buffer-file-name)) (expand-file-name user-emacs-directory))
-      (add-hook 'after-save-hook (lambda ()
-        (let ((org-confirm-babel-evaluate nil)) (org-babel-tangle)))))))
+      (add-hook 'after-save-hook 'my/org-babel-tangle-no-confirm nil t)))
 
 #+end_src
 


### PR DESCRIPTION
First of all, thanks for amazing effort in creating System Crafters: I am just going through the "emacs from scratch" old playlist and I find it incredibly useful and enjoyable.

I opened this PR because I was curious if we can do automatic tangling in more efficient way. If I am correct, the current logic in this repo (and from the video number 7) is somewhat inefficient, in a way that it will register after-save-hook for every buffer opened with org-mode, and then it will, in that hook, check again and again if that buffer is Emacs.org or not.
However, couldn't we instead do that check just once per buffer, at the moment when we are making a decision if we should register after-save-hook for that buffer or not? That way we register after-save-hook only for Emacs.org buffer (we have to make it a local hook though, that is why additional `nil t` params in the `add-hook` call).

I hope the suggestion is clear, if not, I believe the code in this PR should clear it up.

Thanks!